### PR TITLE
fix: workaround for LookPath check on go build calls

### DIFF
--- a/go/os/exec/exec.go
+++ b/go/os/exec/exec.go
@@ -27,6 +27,21 @@ var ErrNotFound = errors.New("executable file not found in $PATH")
 var ErrWaitDelay = errors.New("exec: WaitDelay expired before I/O complete")
 
 func LookPath(file string) (string, error) {
+	if strings.HasPrefix(file, "/") {
+		d, err := os.Stat(file)
+		if err != nil {
+			return "", &Error{file, err}
+		}
+		m := d.Mode()
+		if m.IsDir() {
+			return "", &Error{file, syscall.EISDIR}
+		}
+
+		// permission bits are not available in current implementation,
+		// simply assume it is executable if it is asking for an absolute path.
+		return file, nil
+	}
+
 	return "", &Error{file, ErrNotFound}
 }
 

--- a/go/os/exec/exec.go
+++ b/go/os/exec/exec.go
@@ -37,7 +37,7 @@ func LookPath(file string) (string, error) {
 			return "", &Error{file, syscall.EISDIR}
 		}
 
-		// permission bits are not available in current implementation,
+		// Permission bits are not available in current implementation,
 		// simply assume it is executable if it is asking for an absolute path.
 		return file, nil
 	}


### PR DESCRIPTION
Go's 1.22/1.23 implementation introduced an extra LookPath call before invoking the compile build commands:

https://github.com/golang/go/blob/1576793c513c5cd8396d1a5b004b546e82efc033/src/cmd/go/internal/work/shell.go#L609-L612

This new behavior breaks the code build because the patched `exec.LookPath` is returning error for every call.

This pull request fixed by performing an extra `os.Stat` call upon target with absolute path (ignoring relative path as `$PATH` is absent at this moment). If the target exists, assume it's valid. Permission bits check is skipped because the current JS side filesystem doesn't provide such information.

I have validated the change in my local with 1.22.10 and 1.23.2:

<details>

<summary>1.23.2 output</summary>

```
$ go mod tidy
Downloading ./pako.min.js
Downloading ./stdfiles.cbor.gz
Downloading ./goversion.txt
Downloading ./bin/go1.23.2.wasm.gz
Downloading ./bin/asm1.23.2.wasm.gz
Downloading ./bin/compile1.23.2.wasm.gz
Downloading ./bin/link1.23.2.wasm.gz
Downloading ./cache/0.cbor.gz
Downloading ./cache/1.cbor.gz
Downloading ./cache/2.cbor.gz
Downloading ./cache/3.cbor.gz
Downloading ./cache/4.cbor.gz
Downloading ./cache/5.cbor.gz
Downloading ./cache/6.cbor.gz
Downloading ./cache/7.cbor.gz
Downloading ./cache/8.cbor.gz
Downloading ./cache/9.cbor.gz
Downloading ./cache/a.cbor.gz
Downloading ./cache/b.cbor.gz
Downloading ./cache/c.cbor.gz
Downloading ./cache/d.cbor.gz
Downloading ./cache/e.cbor.gz
Downloading ./cache/f.cbor.gz
Downloading ./wasm_exec.js
$ go build -x -o main.wasm main.go
WORK=/tmp/go-build1387431656
mkdir -p $WORK/b001/
cat >/tmp/go-build1387431656/b001/importcfg << 'EOF' # internal
# import config
packagefile fmt=/var/cache/2a/2acf04c2e296f5a7ff3b16791b68628777e6469db52168fd9f7631120ceba11c-d
packagefile runtime=/var/cache/41/4195d41e94a2a110de748af0be12159d1c9650002d2d2140e51a4bf447484e78-d
EOF
cd /root
/go/pkg/tool/js_wasm/compile -o $WORK/b001/_pkg_.a -trimpath "$WORK/b001=>" -p main -lang=go1.23 -complete -buildid YLt2V4ahacYQRilPoqAA/YLt2V4ahacYQRilPoqAA -dwarf=false -goversion go1.23.2 -nolocalimports -importcfg $WORK/b001/importcfg -pack ./main.go
/go/pkg/tool/js_wasm/buildid -w $WORK/b001/_pkg_.a # internal
cp $WORK/b001/_pkg_.a /var/cache/bf/bf75b6600b149ab0bb83c48516bb6ef8a18f4bc9da19d55a8b27f43de3b6390c-d # internal
cat >/tmp/go-build1387431656/b001/importcfg.link << 'EOF' # internal
packagefile command-line-arguments=/tmp/go-build1387431656/b001/_pkg_.a
packagefile fmt=/var/cache/2a/2acf04c2e296f5a7ff3b16791b68628777e6469db52168fd9f7631120ceba11c-d
packagefile runtime=/var/cache/41/4195d41e94a2a110de748af0be12159d1c9650002d2d2140e51a4bf447484e78-d
packagefile errors=/var/cache/6a/6aafb87d73834e6369415a42edc7d02c253399214f24b03ce4f43aacb2f83f0f-d
packagefile internal/fmtsort=/var/cache/26/2642fb1700e3d8bb58d56e9efc484bd4f0346bc43332bdc036bab6fa537e74bd-d
packagefile io=/var/cache/cd/cd3d9a931cd89dbb6e33d681fa02e937a8755f194d9339560af1533de5e0f736-d
packagefile math=/var/cache/3d/3da4c8ef1dc5da80cc6cd341bfb9e3ffaff0f4c83323f4a87b4075402debf28a-d
packagefile os=/var/cache/8f/8ffa5199ef89a0b2e2b439433e3d0a7e09c369d0877daa8d406b0778e5f77246-d
packagefile reflect=/var/cache/e1/e16816a5e747fafa9fb84457c019a08e0de2502f00e5562c7ffe4b907d7f77f1-d
packagefile slices=/var/cache/3d/3de0223f325902207c42aed79940355a4193d6a68a2f58d07ea9e7a2818df72c-d
packagefile strconv=/var/cache/3a/3ae71ceb5d2bc44ca2527acc7c218f721fc5203e6de712463435c5a8ea066bd7-d
packagefile sync=/var/cache/19/1976188498d5d7146dc59e62d6129b591ecb2df59f73caee72de685b63934165-d
packagefile unicode/utf8=/var/cache/46/46c949f65194302a956cb3b28fec65af4cf91c9d3edab5d00f12c7edaad5da92-d
packagefile internal/abi=/var/cache/89/899f5618e671089b77a5a906303d36e8ac7e3546e77eda070a022b453883c44c-d
packagefile internal/bytealg=/var/cache/6d/6dc2501062c9164babfaccf1667ff81062996caaf5f12cf19ecfc01f18ff02d6-d
packagefile internal/chacha8rand=/var/cache/3b/3bff1f804f82b2b580586453f90af1896fbd46145f85147c2cdc4456f216eb16-d
packagefile internal/coverage/rtcov=/var/cache/f9/f90fef5571b089a4863cb7421b1767bf5c92a51aa35b4a06ba4294b5515af26c-d
packagefile internal/cpu=/var/cache/54/54def3700c024bffc7f85ce3fcdce459f1983d8f36cd7c839e636baa701a3868-d
packagefile internal/goarch=/var/cache/65/651b7e4ffca083ef87c5d7c5dc3529d18af21ce4b269c80d358a05f0cd80a858-d
packagefile internal/godebugs=/var/cache/55/551bcc63536c4b2048ff02f7ab3322fec790e806f210efd13b851d2488737f32-d
packagefile internal/goexperiment=/var/cache/f1/f16e0183bca986def86edcc3930f3741fe2f733b9d7e03c1421aff3dfc64df05-d
packagefile internal/goos=/var/cache/b9/b9d24c566a8c155e58690b825855f5af4a282c7bdbf5a546a9927eac9ef4934d-d
packagefile internal/profilerecord=/var/cache/5a/5abb9b6708cfff5703c377e09382fe43f29db78c832a35a0a24a5624a80f48c4-d
packagefile internal/runtime/atomic=/var/cache/ca/cae6c50252d9e8d260f76003fc7c39d6d03cf506e5db21379aea994f601a3234-d
packagefile internal/runtime/exithook=/var/cache/7a/7a30ac6fa2a741373e0b4a0e58f5944dd860fd9253201de171bf8c716a5e7d84-d
packagefile internal/stringslite=/var/cache/9d/9d4e05b4f777316c42e124d2446dfb8484f07770cad393bbbcb61e2d306310db-d
packagefile runtime/internal/math=/var/cache/45/4562ae9cc8a33d8acdb4dcdd0a0a14078639aa3bd281730da57e6bfcf10f1a54-d
packagefile runtime/internal/sys=/var/cache/02/0236b4e705c39e2082d8adc38e6b154a85d4565dd9a9904162fc1fd6cd185743-d
packagefile internal/reflectlite=/var/cache/f4/f4746f7d6da4f6a058b1ed74d7eee474152f1b66040f38af746fcb577e402d84-d
packagefile cmp=/var/cache/95/95fa485aa1bbc5b785f26edb761f5704f0aa30d5ff8a4705eac5eaeecf31c478-d
packagefile math/bits=/var/cache/6e/6e51780084f717a310b643a9a16c9769c4b6c0ebd0aa937c9b8cabf04f3833f5-d
packagefile internal/byteorder=/var/cache/0a/0ae9c6e7dcc8b36779170c5e935b7a5220c12c0f11693c0188c9dc2edb960ea5-d
packagefile internal/filepathlite=/var/cache/13/1303b6766c6c0896bf579d066c331a93e2d8c95c4f325601e886bb26cf0b925c-d
packagefile internal/itoa=/var/cache/9e/9e591ddbc07f88142778a8af348b5a0b8cd9abafb602df225bc3d5a68b4b7db6-d
packagefile internal/poll=/var/cache/15/15cca4f0710a70b7e2157e2f8e0a316b5bfa2f1df27b671bc9379664f22c8d7d-d
packagefile internal/syscall/execenv=/var/cache/61/618c206704b97112617375518e4541b88d41bf5680a48bcde48a8f998d28ec3b-d
packagefile internal/syscall/unix=/var/cache/38/38b3e867439f26b90dc882b42b6d0ec79db8676066818f7a477d615a2b235769-d
packagefile internal/testlog=/var/cache/6a/6acb457d22567381f1e2262b7849187d5a170c93c811618b48b2f3b591d0968a-d
packagefile io/fs=/var/cache/a2/a2d59572b83401f985b05cef54620b502b5c23c473ba4c47998fb5047d55cb8c-d
packagefile sync/atomic=/var/cache/f5/f57354736f0910e465a071ead771a0eb0ceda0fce8a47848889fd7f914148c19-d
packagefile syscall=/var/cache/7a/7aebb64ab596b32f4af5cf0b5e2dfe62afbaa2c304c6967bafe9a36c4576f8c2-d
packagefile time=/var/cache/e3/e338ec80d454e32f49230f513adc017a857c2a38a19822ca8413978e6ece2c2c-d
packagefile internal/unsafeheader=/var/cache/0d/0d4676d4176a2f55631b06b75a098978a981033b8ec46605e323fa8d9f204ce5-d
packagefile iter=/var/cache/f0/f038f15d2d6df887e2b1dd25ad05b2042a17223fcb2c95a5159e75365500cd4a-d
packagefile unicode=/var/cache/b5/b5b6c9ffd69ec319163a24dbb4684ea906f27faf219b2548c2e892925874fff4-d
packagefile internal/race=/var/cache/cc/cc65ac3a9934ed4ad43e8fb20df26400e83eaca4c892a2ab1e4e9e879a414f5b-d
packagefile internal/oserror=/var/cache/a1/a1782ad87074cb686ced43b087ca5a16fb99e2f264c979e8aef03eaf4f0edcb7-d
packagefile path=/var/cache/66/660def2c92c517ebbf9cecd0f07910c01f2ced001ddab7e19a3b1e53066e18c2-d
packagefile syscall/js=/var/cache/d5/d5affbbd844c03fc8988b7dc23f5860ff7d954700584b3a049a59920ec556f81-d
packagefile internal/godebug=/var/cache/a6/a6723fd5a8a12272367a2b2fa6bd20126101802383de434f8b84dbbe70f551c1-d
packagefile internal/bisect=/var/cache/41/41c774810bbc83a000f58638f099228c3bdc2979b84f89fa4a3dc9bdb7982115-d
modinfo "0w\xaf\f\x92t\b\x02A\xe1\xc1\a\xe6\xd6\x18\xe6path\tcommand-line-arguments\nbuild\t-buildmode=exe\nbuild\t-compiler=gc\nbuild\tCGO_ENABLED=0\nbuild\tGOARCH=wasm\nbuild\tGOOS=js\n\xf92C1\x86\x18 r\x00\x82B\x10A\x16\xd8\xf2"
EOF
mkdir -p $WORK/b001/exe/
cd .
GOROOT='/go' /go/pkg/tool/js_wasm/link -o $WORK/b001/exe/a.out -importcfg $WORK/b001/importcfg.link -buildmode=exe -buildid=nVZ2GPvF78Cph5qBDUqI/YLt2V4ahacYQRilPoqAA/6MHeQE7U0ZdqB7jskx8p/nVZ2GPvF78Cph5qBDUqI -extld=gcc $WORK/b001/_pkg_.a
/go/pkg/tool/js_wasm/buildid -w $WORK/b001/exe/a.out # internal
mv $WORK/b001/exe/a.out main.wasm
rm -rf $WORK/b001/
Hello, World!
```

</details>